### PR TITLE
Tag 아토믹 컴포넌트 제작 완료

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,5 +17,6 @@ module.exports = {
     'import/no-unresolved': 0,
     'react/prop-types': 0,
     'no-unused-vars': 'warn',
+    'import/no-extraneous-dependencies': 0,
   },
 };

--- a/src/App.js
+++ b/src/App.js
@@ -3,13 +3,17 @@ import React from 'react';
 import { Switch, Route } from 'react-router-dom';
 
 import P from '@pages';
+import GlobalStyles from '@styles/globalStyles';
 // import DetailPage from '@/pages/DetailPage';
 
 export default function App() {
   return (
-    <Switch>
-      <Route exact path="/" component={P.LandingPage} />
-      {/* <Route exact path="/detail:id" component={DetailPage} /> */}
-    </Switch>
+    <>
+      <GlobalStyles />
+      <Switch>
+        <Route exact path="/" component={P.LandingPage} />
+        {/* <Route exact path="/detail:id" component={DetailPage} /> */}
+      </Switch>
+    </>
   );
 }

--- a/src/atoms/Tag/Tag.js
+++ b/src/atoms/Tag/Tag.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import styled from 'styled-components';
+import { darken } from 'polished';
+
+import colorType from '@constants/colorType';
+
+const Wrapper = styled.div`
+  width: fit-content;
+  height: 26px;
+  background-color: ${({ backgroundColor }) => backgroundColor};
+  color: ${({ fontColor }) => fontColor};
+  display: fles;
+  justify-content: center;
+  align-items: center;
+  margin: 5px;
+  border-radius: 13px;
+  &:hover {
+    background-color: ${({ backgroundColor }) => darken(0.04, backgroundColor)};
+  }
+`;
+
+const WrapText = styled.div`
+  padding-left: 10px;
+<<<<<<< HEAD
+  ${({ hasX }) => (hasX === true ? 'padding-right: 5px;' : 'padding-right: 10px;')}
+=======
+  ${({ hasX }) => (hasX ? 'padding-right: 5px;' : 'padding-right: 10px;')}
+>>>>>>> b423f13 (chore(env): styled-components GlobalStyles 적용)
+  font-size: 12px;
+  font-weight: bold;
+`;
+
+const WrapCancel = styled.div`
+  display: fles;
+  justify-content: center;
+  align-items: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 13px;
+  background-color: ${({ backgroundColor }) => backgroundColor};
+  cursor: pointer;
+  font-size: 12px;
+  &:hover {
+    background: ${({ backgroundColor }) => darken(0.04, backgroundColor)};
+  }
+`;
+
+export default function Tag({
+  text, func, type = 0,
+}) {
+  return (
+    <Wrapper
+      fontColor={colorType[type].fontColor}
+      backgroundColor={colorType[type].background}
+    >
+      <WrapText hasX={func}>{text}</WrapText>
+      {func && (
+        <WrapCancel backgroundColor={colorType[type].background} onClick={func}>
+          ✕
+        </WrapCancel>
+      )}
+    </Wrapper>
+  );
+}

--- a/src/atoms/Tag/Tag.js
+++ b/src/atoms/Tag/Tag.js
@@ -21,11 +21,7 @@ const Wrapper = styled.div`
 
 const WrapText = styled.div`
   padding-left: 10px;
-<<<<<<< HEAD
   ${({ hasX }) => (hasX === true ? 'padding-right: 5px;' : 'padding-right: 10px;')}
-=======
-  ${({ hasX }) => (hasX ? 'padding-right: 5px;' : 'padding-right: 10px;')}
->>>>>>> b423f13 (chore(env): styled-components GlobalStyles 적용)
   font-size: 12px;
   font-weight: bold;
 `;

--- a/src/atoms/Tag/index.js
+++ b/src/atoms/Tag/index.js
@@ -1,0 +1,1 @@
+export { default } from './Tag';

--- a/src/atoms/index.js
+++ b/src/atoms/index.js
@@ -1,0 +1,3 @@
+import Tag from './Tag';
+
+export default { Tag };

--- a/src/constants/colorType.js
+++ b/src/constants/colorType.js
@@ -1,0 +1,8 @@
+const colorType = [
+  {
+    background: '#f2f8fe',
+    fontColor: '#437cd6',
+  },
+];
+
+export default colorType;


### PR DESCRIPTION
> resolve #4 

- 디자인 나오기 전 GitHub 태그 형태 카피 -> 추후에 사용
- polished로 darken을 이용해 hover 컬러 값 변경
- 취소버튼 동작 및 조건부 렌더링 가능하도록 props 구조 추가
- @constants/colorType.js 에 객체배열 형태로 정의하고 index를 type props로 지정해 접근할 수 있음

<img width="103" alt="Screen Shot 2021-02-04 at 5 56 50 PM" src="https://user-images.githubusercontent.com/16266103/106869633-8185c800-6713-11eb-9cc4-048fc18001a7.png">
