### PR TITLE
overflow: auto; 시 scroll이 안먹는 문제 해결 및 스크롤 hide

### DIFF
--- a/src/components/CardBox/CardBox.js
+++ b/src/components/CardBox/CardBox.js
@@ -14,7 +14,10 @@ const CardContainer = styled.div`
   height: 70vh;
   flex-direction: column;
   flex-wrap: wrap;
-  overflow: hidden;
+  overflow: auto;
+  ::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const CardList = styled.ul`
@@ -22,7 +25,6 @@ const CardList = styled.ul`
   flex-wrap: wrap;
   margin: 0 auto;
   align-content: flex-start;
-
 `;
 
 const CardBoxWrapper = styled.div`
@@ -79,20 +81,18 @@ function CardBox({ page }) {
 
   return (
     <CardBoxWrapper>
-
       <CardContainer>
         <CardList>
-          {!loading && success
-             && (
-               <>
-                 {removeToggle && (
-                 <>
-                   <DeleteBox toyId={toyId} setRemoveToggle={setRemoveToggle} />
-                 </>
-                 )}
-                 {loopToys(data)}
-               </>
-             )}
+          {!loading && success && (
+            <>
+              {removeToggle && (
+                <>
+                  <DeleteBox toyId={toyId} setRemoveToggle={setRemoveToggle} />
+                </>
+              )}
+              {loopToys(data)}
+            </>
+          )}
         </CardList>
       </CardContainer>
     </CardBoxWrapper>


### PR DESCRIPTION
- QA 해결하면서 생긴 이슈 scroll을 숨기기위해 사용한 overflow: auto; 로 인해 스크롤이 안되는 문제 생김
- 아래 코드를 사용해서 해결

::-webkit-scrollbar {
    display: none;
}