### PR TITLE
쓰로틀링 추가, 스피너 초기 지연 설정

### DIFF
--- a/src/atoms/Spinner/Spinner.js
+++ b/src/atoms/Spinner/Spinner.js
@@ -1,20 +1,8 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import styled from 'styled-components';
 
-const Spinner = () => (
-  <StyledSpinner viewBox="0 0 50 50">
-    <circle
-      className="path"
-      cx="25"
-      cy="25"
-      r="20"
-      fill="none"
-      strokeWidth="4"
-    />
-  </StyledSpinner>
-);
-
 const StyledSpinner = styled.svg`
+  display: none;
   animation: rotate 1s linear infinite;
   width: 60px;
   height: 60px;
@@ -45,5 +33,29 @@ const StyledSpinner = styled.svg`
     }
   }
 `;
+
+const Spinner = () => {
+  const spinnerRef = useRef();
+  useEffect(() => {
+    setTimeout(() => {
+      if (spinnerRef.current) {
+        spinnerRef.current.style.display = 'flex';
+      }
+    }, 100);
+  }, []);
+
+  return (
+    <StyledSpinner viewBox="0 0 50 50" ref={spinnerRef}>
+      <circle
+        className="path"
+        cx="25"
+        cy="25"
+        r="20"
+        fill="none"
+        strokeWidth="4"
+      />
+    </StyledSpinner>
+  );
+};
 
 export default Spinner;

--- a/src/pages/LandingPage/LandingPage.js
+++ b/src/pages/LandingPage/LandingPage.js
@@ -1,10 +1,9 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled, { keyframes } from 'styled-components';
 import LandingWallpaper from '@assets/images/LandingWallpaper.png';
 
 import C from '@components';
 import { useSelector } from 'react-redux';
-import useIntersectionObserver from '@hooks/useIntersectionObserver';
 import { respondTo } from '@utils/mixin';
 
 const slideUp = keyframes`
@@ -83,20 +82,27 @@ const Main = styled.div`
 
 export default function LandingPage() {
   const [isDraw, setIsDraw] = useState(false);
-  const [target, setTarget] = useState(null);
+
+  let timer;
+  const throttle = () => {
+    if (!timer) {
+      timer = setTimeout(() => {
+        timer = null;
+        if (document.documentElement.scrollTop > 50) {
+          setIsDraw(true);
+        }
+      }, 200);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener('scroll', throttle);
+    return () => window.removeEventListener('scroll', throttle);
+  }, []);
 
   const { loading: getToysLoading, success: getToysSuccess } = useSelector(
     (state) => state.getToy.getToysStatus,
   );
-
-  useIntersectionObserver({
-    target,
-    onIntersect: ([{ isIntersecting }]) => {
-      if (isIntersecting) {
-        setIsDraw(true);
-      }
-    },
-  });
 
   return (
     <>
@@ -118,17 +124,11 @@ export default function LandingPage() {
               </Main>
             )
             : (
-              <>
-                <Curtain>
-                  <WallPaper active>
-                    <img src={LandingWallpaper} alt="welcome wallpaper" />
-                  </WallPaper>
-                </Curtain>
-                <div
-                  ref={setTarget}
-                  className="last-item"
-                />
-              </>
+              <Curtain>
+                <WallPaper active>
+                  <img src={LandingWallpaper} alt="welcome wallpaper" />
+                </WallPaper>
+              </Curtain>
             )}
         </WrapContainer>
       </Wrapper>


### PR DESCRIPTION
### Summary

* 랜딩 페이지 커튼 컴포넌트 스크롤 이벤트 쓰로틀링 구현
  * 인피니티 스크롤의 경우 Intersection Observer API를 사용했기 때문에 디바운싱이 불필요하다고 판단되었습니다.
* 스피너가 포함된 컴포넌트가 마운트된 후 로딩이 1초 이상 지연될 경우에만 스피너가 생기도록 수정
  * resolves #61 